### PR TITLE
add number modifier to default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Currently supported modifiers:
 - `[string]` Indicates that the value of the parameter must be set to `""`.
 - `[nullable]` Indicates that the parameter value can be set to `null`.
 - `[default: DEFAULT_VALUE]` Sets the default value to `DEFAULT_VALUE`.
+- `[number]` Indicates that the value of the parameter must be set to a number (ex. `0`).
 
 The modifiers are also customizable via the [configuration file](#configuration-file).
 
@@ -140,8 +141,8 @@ Custom configuration snippet:
   ...
     "modifiers": {
     "array": "array",
-    "object": "object"
-    "string": "string"
+    "object": "object",
+    "string": "string",
     "nullable": "nullable",
     "number": "number"
   },
@@ -168,9 +169,10 @@ The configuration file has the following structure:
   },
   "modifiers": {
     "array": "array",                            <-- Modifier that indicates an array type
-    "object": "object"                           <-- Modifier that indicates an object type
-    "string": "string"                           <-- Modifier that indicates a string type
-    "nullable": "nullable"                       <-- Modifier that indicates a parameter that can be set to null
+    "object": "object",                          <-- Modifier that indicates an object type
+    "string": "string",                          <-- Modifier that indicates a string type
+    "nullable": "nullable",                      <-- Modifier that indicates a parameter that can be set to null
+    "number": "number"                           <-- Modifier that indicates a number type
   },
   "regexp": {
     "paramsSectionTitle": "Parameters"           <-- Title of the parameters section to replace in the README.md

--- a/config.json
+++ b/config.json
@@ -15,7 +15,8 @@
     "object": "object",
     "string": "string",
     "nullable": "nullable",
-    "default": "default"
+    "default": "default",
+    "number": "number"
   },
   "regexp": {
     "paramsSectionTitle": "Parameters"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Autogenerate READMEs tables and OpenAPI schemas for Helm Charts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Update the default configuration to contain the _number_ modifier. Currently, if you try to add the below sample the generator will fail saying _number_ is an unknown modifier.

YAML

```yaml
## @param test [string,number] A test value to represent a string or a number
test: ""
```
Output
```
Error: Unknown modifier: number for parameter test
```

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows consumers to use the _number_ modifier without providing a custom configuration.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

### Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x ] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [ x ] New features are documented in the README.md
- [ x ] New features contain a new test at the `tests` folder
- [ x ] All tests pass running `npm test`
