### PR TITLE
add number modifier to default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Currently supported modifiers:
 - `[array]` Indicates that the value of the parameter must be set to `[]`.
 - `[object]` Indicates that the value of the parameter must be set to `{}`.
 - `[string]` Indicates that the value of the parameter must be set to `""`.
+- `[number]` Indicates that the value of the parameter must be set to a number (ex. `0`).
 - `[nullable]` Indicates that the parameter value can be set to `null`.
 - `[default: DEFAULT_VALUE]` Sets the default value to `DEFAULT_VALUE`.
 
@@ -141,10 +142,10 @@ Custom configuration snippet:
   ...
     "modifiers": {
     "array": "array",
-    "object": "object"
-    "string": "string"
-    "nullable": "nullable",
-    "number": "number"
+    "object": "object",
+    "string": "string",
+    "number": "number",
+    "nullable": "nullable"
   },
   ...
 }
@@ -169,9 +170,10 @@ The configuration file has the following structure:
   },
   "modifiers": {
     "array": "array",                            <-- Modifier that indicates an array type
-    "object": "object"                           <-- Modifier that indicates an object type
-    "string": "string"                           <-- Modifier that indicates a string type
-    "nullable": "nullable"                       <-- Modifier that indicates a parameter that can be set to null
+    "object": "object",                          <-- Modifier that indicates an object type
+    "string": "string",                          <-- Modifier that indicates a string type
+    "number": "number",                           <-- Modifier that indicates a number type
+    "nullable": "nullable"                      <-- Modifier that indicates a parameter that can be set to null
   },
   "regexp": {
     "paramsSectionTitle": "Parameters"           <-- Title of the parameters section to replace in the README.md

--- a/config.json
+++ b/config.json
@@ -14,6 +14,7 @@
     "array": "array",
     "object": "object",
     "string": "string",
+    "number": "number",
     "nullable": "nullable",
     "default": "default"
   },

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -30,6 +30,8 @@ function applyModifiers(param, config) {
         case `${config.modifiers.string}`:
           param.value = '""';
           break;
+        case `${config.modifiers.number}`:
+          break;
         case `${config.modifiers.nullable}`:
           // Do nothing since the nullable parameters must preserve its default value
           // unless another modifier is applied at the same time. In that case, the second

--- a/lib/render.js
+++ b/lib/render.js
@@ -271,6 +271,9 @@ function renderOpenAPISchema(schemaFilePath, parametersList, config) {
           case `${config.modifiers.string}`:
             p.type = 'string';
             break;
+          case `${config.modifiers.number}`:
+            p.type = 'number';
+            break;
           default:
             break;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitnami/readme-generator-for-helm",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Autogenerate READMEs tables and OpenAPI schemas for Helm Charts",
   "main": "index.js",
   "scripts": {

--- a/tests/expected-readme.first-execution.md
+++ b/tests/expected-readme.first-execution.md
@@ -121,6 +121,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -137,6 +138,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/expected-readme.last-section-text-below.md
+++ b/tests/expected-readme.last-section-text-below.md
@@ -159,6 +159,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -175,6 +176,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/expected-readme.last-section.md
+++ b/tests/expected-readme.last-section.md
@@ -159,6 +159,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -175,6 +176,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -159,6 +159,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -175,6 +176,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/expected-schema.json
+++ b/tests/expected-schema.json
@@ -573,6 +573,11 @@
                 "type": "string"
             }
         },
+        "numberModifier": {
+            "type": "number",
+            "description": "Test parameter for modifier number",
+            "default": 0
+        },
         "configuration": {
             "type": "string",
             "description": "haproxy configuration",
@@ -686,6 +691,12 @@
         "nullableNullString": {
             "type": "string",
             "description": "Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.",
+            "default": null,
+            "nullable": true
+        },
+        "nullableNullNumber": {
+            "type": "number",
+            "description": "Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.",
             "default": null,
             "nullable": true
         },

--- a/tests/test-readme.last-section-text-below.md
+++ b/tests/test-readme.last-section-text-below.md
@@ -159,6 +159,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -175,6 +176,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/test-readme.last-section.md
+++ b/tests/test-readme.last-section.md
@@ -159,6 +159,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -175,6 +176,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/test-readme.md
+++ b/tests/test-readme.md
@@ -159,6 +159,7 @@ This description starts in a new line instead of the same line of description st
 | `serviceAccount.name`                                 | Name of the created ServiceAccount                                                                                             | `""`         |
 | `inventedArray`                                       | Test parameter to check arrays                                                                                                 | `["a","b"]`  |
 | `arrayModifier`                                       | Test parameter for modifier array                                                                                              | `[]`         |
+| `numberModifier`                                      | Test parameter for modifier number                                                                                             | `0`          |
 | `configuration`                                       | haproxy configuration                                                                                                          | `""`         |
 | `jobs[0].nameOverride`                                | String to partially override jobs.names.fullname                                                                               | `""`         |
 | `jobs[0].fullnameOverride`                            | String to fully override jobs.names.fullname                                                                                   | `""`         |
@@ -175,6 +176,7 @@ This description starts in a new line instead of the same line of description st
 | `nullableNullStringWithValueChange`                   | Nullable null string. We apply string modifier that will change the type and value, but the schema will show `nullable: true`. | `""`         |
 | `nullableNullArray`                                   | Nullable null array. We apply array modifier that will change the type in the schema plus `nullable: true`.                    | `nil`        |
 | `nullableNullString`                                  | Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
+| `nullableNullNumber`                                  | Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.          | `nil`        |
 | `nullableNotNull`                                     | Nullable parameter with a non null value                                                                                       | `somestring` |
 | `nullableObject`                                      | Nullable parameter with an object value                                                                                        | `{}`         |
 | `nullableArray`                                       | Nullable parameter with an array value                                                                                         | `[]`         |

--- a/tests/test-schema.json
+++ b/tests/test-schema.json
@@ -573,6 +573,11 @@
                 "type": "string"
             }
         },
+        "numberModifier": {
+            "type": "number",
+            "description": "Test parameter for modifier number",
+            "default": 0
+        },
         "configuration": {
             "type": "string",
             "description": "haproxy configuration",
@@ -686,6 +691,12 @@
         "nullableNullString": {
             "type": "string",
             "description": "Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.",
+            "default": null,
+            "nullable": true
+        },
+        "nullableNullNumber": {
+            "type": "number",
+            "description": "Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.",
             "default": null,
             "nullable": true
         },

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -459,6 +459,10 @@ arrayModifier:
   - a
   - b
 
+## Invented parameter to test number modifier
+## @param numberModifier [number] Test parameter for modifier number
+numberModifier: 0
+
 ## @param configuration [string] haproxy configuration
 ##
 configuration: |
@@ -521,6 +525,8 @@ nullableNullStringWithValueChange: null
 nullableNullArray: null
 ## @param nullableNullString [string,nullable] Nullable null string. We apply string modifier to avoid infering an object type. The null must be preverved as value.
 nullableNullString: null
+## @param nullableNullNumber [number,nullable] Nullable null number. We apply number modifier to avoid infering an object type. The null must be preverved as value.
+nullableNullNumber: null
 ## @param nullableNotNull [nullable] Nullable parameter with a non null value
 nullableNotNull: somestring
 ## @param nullableObject [nullable] Nullable parameter with an object value


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Update the default configuration to contain the _number_ modifier. Currently, if you try to add the below sample the generator will fail saying _number_ is an unknown modifier.

YAML

```yaml
## @param test [string,number] A test value to represent a string or a number
test: ""
```
Output
```
Error: Unknown modifier: number for parameter test
```

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows consumers to use the _number_ modifier without providing a custom configuration.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

### Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x ] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [ x ] New features are documented in the README.md
- [ x ] New features contain a new test at the `tests` folder
- [ x ] All tests pass running `npm test`
