### PR TITLE
Preserve whitespace in descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,10 @@ Add this to your `.pre-commit-config.yaml`:
 
 ## Versions
 
+### 2.8.0
+
+Descriptions now discard only a single whitespace. This way, code blocks can use proper indentation.
+
 ### 2.4.0
 
 Add `descriptionStart` and `descriptionEnd` config options (default tags: `@descriptionStart` and `@descriptionEnd`)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -30,7 +30,7 @@ function parseMetadataComments(valuesFilePath, config) {
   const paramRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.param}\\s*([^\\s]+)\\s*(\\[.*?\\])?\\s*(.*)$`);
   const sectionRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.section}\\s*(.*)$`);
   const descriptionStartRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.descriptionStart}\\s*(.*)`);
-  const descriptionContentRegex = new RegExp(`^\\s*${config.comments.format}\\s*(.*)`);
+  const descriptionContentRegex = new RegExp(`^\\s*${config.comments.format}\\s?(.*)`);
   const descriptionEndRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.descriptionEnd}\\s*(.*)`);
   const skipRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.skip}\\s*([^\\s]+)\\s*(.*)$`);
   const extraRegex = new RegExp(`^\\s*${config.comments.format}\\s*${config.tags.extra}\\s*([^\\s]+)\\s*(\\[.*?\\])?\\s*(.*)$`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitnami/readme-generator-for-helm",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Autogenerate READMEs tables and OpenAPI schemas for Helm Charts",
   "main": "index.js",
   "scripts": {

--- a/tests/expected-readme.config.md
+++ b/tests/expected-readme.config.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/expected-readme.first-execution.md
+++ b/tests/expected-readme.first-execution.md
@@ -4,6 +4,15 @@
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/expected-readme.last-section-text-below.md
+++ b/tests/expected-readme.last-section-text-below.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/expected-readme.last-section.md
+++ b/tests/expected-readme.last-section.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/expected-readme.md
+++ b/tests/expected-readme.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/test-readme.config.md
+++ b/tests/test-readme.config.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/test-readme.last-section-text-below.md
+++ b/tests/test-readme.last-section-text-below.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/test-readme.last-section.md
+++ b/tests/test-readme.last-section.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/test-readme.md
+++ b/tests/test-readme.md
@@ -42,6 +42,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
+Example:
+
+```yaml
+global:
+  imageRegistry: myRegistryName
+  imagePullSecrets:
+    - myRegistryKeySecretName
+```
+
 | Name                      | Description                                     | Value |
 | ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |

--- a/tests/test-values.yaml
+++ b/tests/test-values.yaml
@@ -5,10 +5,16 @@
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
 ##
-# global:
-#   imageRegistry: myRegistryName
-#   imagePullSecrets:
-#     - myRegistryKeySecretName
+## @descriptionStart
+## Example:
+##
+## ```yaml
+## global:
+##   imageRegistry: myRegistryName
+##   imagePullSecrets:
+##     - myRegistryKeySecretName
+## ```
+## @descriptionEnd
 global:
   imageRegistry: ""
   imagePullSecrets: []


### PR DESCRIPTION
### Description of the change

Only a single, leading whitespace will be preserved in description lines.

### Benefits

Markdown code blocks can now be added to the description without loosing indentation.

### Possible drawbacks

If there were more than a single, leading whitespace, those will now show up in the output.

### Applicable issues

Fixes #62

### Checklist

- [X] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [X] New features are documented in the README.md
- [X] New features contain a new test at the `tests` folder
- [X] All tests pass running `npm test`
