### PR TITLE
Prepare bugfix release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.8.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitnami/readme-generator-for-helm",
-      "version": "2.8.0",
+      "version": "2.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitnami/readme-generator-for-helm",
-  "version": "2.8.0",
+  "version": "2.7.1",
   "description": "Autogenerate READMEs tables and OpenAPI schemas for Helm Charts",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description of the change

Last official release was 2.7.0, according to semver, the new release should be 2.7.1 because it contains only bugfixes:
* #141
*  #145
* #143
* #144

### Benefits

Use right version

### Possible drawbacks

None

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

### Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Version bumped in `package.json` and `package-lock.json` according to [semver](http://semver.org/).
- [ ] New features are documented in the README.md
- [ ] New features contain a new test at the `tests` folder
- [X] All tests pass running `npm test`
